### PR TITLE
Fix: Weißer Bildschirm nach Neuladen mit aktivierter Session-Persistenz

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -13,7 +13,7 @@ import { StatusBar } from 'expo-status-bar';
 import { AuthProvider, useAuth } from '@/lib/authContext';
 
 // [VERHINDERT] Automatisches Verschwinden des Splash-Screens
-SplashScreen.preventAutoHideAsync();
+// Anmerkung: preventAutoHideAsync() wird bereits in authContext.ts aufgerufen
 
 // [DEFINIERT] Inneres Layout ohne Authentifizierungsprüfung
 function RootLayoutNav() {

--- a/lib/authContext.ts
+++ b/lib/authContext.ts
@@ -110,6 +110,9 @@ export const AuthProvider = ({ children }: AuthProvider): React.ReactElement => 
   // [ÜBERWACHT] Authentifizierungsstatuswechsel beim Komponenten-Mount
   useEffect(() => {
     console.log("AuthProvider wird initialisiert");
+    
+    // [WICHTIG] Stellen sicher, dass der SplashScreen angezeigt wird, bis die Auth abgeschlossen ist
+    SplashScreen.preventAutoHideAsync().catch(console.warn);
 
     // [ABONNIERT] Authentifizierungsstatuswechsel von Supabase
     const { data: authListener } = supabase.auth.onAuthStateChange(
@@ -209,7 +212,11 @@ export const AuthProvider = ({ children }: AuthProvider): React.ReactElement => 
           // [LÄDT] Benutzerprofil für vorhandene Sitzung
           const userProfile = await loadUserProfile(session.user.id);
           if (userProfile) {
-            console.log("Profil für bestehende Session gefunden");
+            console.log("Profil für bestehende Session gefunden, navigiere zur Team-Auswahl");
+            // [WICHTIG] Navigation zur Team-Auswahl bei bestehendem Profil nach Reload
+            setTimeout(() => {
+              router.replace('/features/teams/screens/selection');
+            }, 100);
           } else {
             console.log("Kein Profil für bestehende Session gefunden");
           }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -221,6 +221,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
     autoRefreshToken: true,
     persistSession: true,
     detectSessionInUrl: true,
+    debug: true, // [WICHTIG] Aktiviere Debug-Modus für bessere Fehlerdiagnose
   },
   global: {
     headers: {


### PR DESCRIPTION
## Problem
Bei aktivierter "Erinnere mich"-Funktion (Session-Persistenz) funktioniert der Login korrekt, aber wenn der Tab geschlossen und localhost:8081 neu aufgerufen wird, erscheint nur ein weißer Bildschirm.

## Ursache
Das Problem tritt auf, weil der Authentifizierungskontext zwar korrekt die persistierte Sitzung wiederherstellt, aber die Navigation zur entsprechenden Route (Team-Auswahl) nach dem Neuladen nicht automatisch ausgeführt wird.

## Lösung
Diese PR beinhaltet folgende Verbesserungen:

1. **Hauptkorrektur**: Navigation nach der Profilabrufung hinzugefügt
   - In `authContext.ts` wurde eine automatische Navigation zur Team-Auswahl implementiert, wenn ein Profil für eine bestehende Sitzung nach dem Neuladen gefunden wird
   - Ein `setTimeout` wurde für die Navigation verwendet, um sicherzustellen, dass sie nach der Profilerkennung ausgeführt wird

2. **SplashScreen-Initialisierung optimiert**
   - Doppelte Initialisierung des SplashScreen vermieden
   - Explizite Fehlerbehandlung für `preventAutoHideAsync()` hinzugefügt

3. **Debugging verbessert**
   - Debug-Modus in der Supabase-Konfiguration aktiviert, um detailliertere Fehlerprotokolle zu erhalten

## Testen
Um diese Fehlerbehebung zu testen:
1. Logge dich mit aktiviertem "Erinnere mich"-Toggle ein
2. Schließe den Tab
3. Navigiere wieder zu localhost:8081
4. Die App sollte jetzt automatisch zur Team-Auswahlanzeige navigieren, anstatt einen weißen Bildschirm anzuzeigen
